### PR TITLE
fix: change the nixcon icon filepath

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <section class="section-hero">
     <div class="hero">
         <div class="hero-logo">
-            <img src="/images/nixcon2022.svg" />
+            <img src="/images/nixcon2020.svg" />
         </div>
         <div class="hero-text">
             <h1>NixCon 2022</h1>


### PR DESCRIPTION
The nixcon logo was not displaying, because its path was updated, regardless of the image name. So I renamed the path in the html to solve the problem.

| Before | After |
|----------|--------|
| ![image](https://user-images.githubusercontent.com/68606322/182672573-a972049f-208c-4166-988c-45f41b403f6a.png) | ![image](https://user-images.githubusercontent.com/68606322/182672689-b99a00a2-49d0-4d7d-ac00-3eda6a6cab9b.png) |
